### PR TITLE
Add check in hook_install to load the editorial workflow directly fro…

### DIFF
--- a/localgov_workflows.install
+++ b/localgov_workflows.install
@@ -6,6 +6,7 @@
  */
 
 use Drupal\Core\Cache\Cache;
+use Drupal\Core\Config\FileStorage;
 use Drupal\scheduled_transitions\Form\ScheduledTransitionsSettingsForm;
 use Drupal\workflows\Entity\Workflow;
 
@@ -16,6 +17,16 @@ function localgov_workflows_install() {
 
   // Add workflow to localgov_ node bundles with no other workflow.
   $editorial = Workflow::load('localgov_editorial');
+
+  if (!$editorial) {
+    $config_path = drupal_get_path('module', 'localgov_workflows') . '/config/install';
+    $config_source = new FileStorage($config_path);
+    $config_storage = \Drupal::service('config.storage');
+    $localgov_editorial = $config_source->read('workflows.workflow.localgov_editorial');
+    $config_storage->write('workflows.workflow.localgov_editorial', $localgov_editorial);
+    $editorial = Workflow::load('localgov_editorial');
+  }
+
   $workflow_type = $editorial->getTypePlugin();
 
   $node_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');

--- a/localgov_workflows.install
+++ b/localgov_workflows.install
@@ -17,18 +17,15 @@ function localgov_workflows_install() {
 
   // Add workflow to localgov_ node bundles with no other workflow.
   $editorial = Workflow::load('localgov_editorial');
-
   if (!$editorial) {
-    $config_path = drupal_get_path('module', 'localgov_workflows') . '/config/install';
-    $config_source = new FileStorage($config_path);
+    $config_source = new FileStorage(drupal_get_path('module', 'localgov_workflows') . '/config/install');
+    $editorial_config = $config_source->read('workflows.workflow.localgov_editorial');
     $config_storage = \Drupal::service('config.storage');
-    $localgov_editorial = $config_source->read('workflows.workflow.localgov_editorial');
-    $config_storage->write('workflows.workflow.localgov_editorial', $localgov_editorial);
+    $config_storage->write('workflows.workflow.localgov_editorial', $editorial_config);
     $editorial = Workflow::load('localgov_editorial');
   }
 
   $workflow_type = $editorial->getTypePlugin();
-
   $node_types = \Drupal::service('entity_type.bundle.info')->getBundleInfo('node');
   $changed = FALSE;
   foreach ($node_types as $type_name => $node_type) {

--- a/localgov_workflows.install
+++ b/localgov_workflows.install
@@ -7,21 +7,32 @@
 
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Config\FileStorage;
+use Drupal\Core\Site\Settings;
 use Drupal\scheduled_transitions\Form\ScheduledTransitionsSettingsForm;
 use Drupal\workflows\Entity\Workflow;
 
 /**
  * Implements hook_install().
  */
-function localgov_workflows_install() {
+function localgov_workflows_install($is_syncing) {
 
   // Add workflow to localgov_ node bundles with no other workflow.
   $editorial = Workflow::load('localgov_editorial');
   if (!$editorial) {
-    $config_source = new FileStorage(drupal_get_path('module', 'localgov_workflows') . '/config/install');
-    $editorial_config = $config_source->read('workflows.workflow.localgov_editorial');
+    $config_key = 'workflows.workflow.localgov_editorial';
+    if ($is_syncing) {
+      // If syncing config try to load the workflow from exported config.
+      $config_source = new FileStorage(Settings::get('config_sync_directory'));
+      $editorial_config = $config_source->read($config_key);
+    }
+    if (!$is_syncing || !$editorial_config) {
+      // If workflow doesn't already exist load it from this module.
+      $config_source = new FileStorage(drupal_get_path('module', 'localgov_workflows') . '/config/install');
+      $editorial_config = $config_source->read($config_key);
+      $editorial_config = ['uuid' => \Drupal::service('uuid')->generate()] + $editorial_config;
+    }
     $config_storage = \Drupal::service('config.storage');
-    $config_storage->write('workflows.workflow.localgov_editorial', $editorial_config);
+    $config_storage->write($config_key, $editorial_config);
     $editorial = Workflow::load('localgov_editorial');
   }
 

--- a/localgov_workflows.install
+++ b/localgov_workflows.install
@@ -29,10 +29,10 @@ function localgov_workflows_install($is_syncing) {
       // If workflow doesn't already exist load it from this module.
       $config_source = new FileStorage(drupal_get_path('module', 'localgov_workflows') . '/config/install');
       $editorial_config = $config_source->read($config_key);
-      $editorial_config = ['uuid' => \Drupal::service('uuid')->generate()] + $editorial_config;
     }
-    $config_storage = \Drupal::service('config.storage');
-    $config_storage->write($config_key, $editorial_config);
+    \Drupal::entityTypeManager()->getStorage('workflow')
+      ->create($editorial_config)
+      ->save();
     $editorial = Workflow::load('localgov_editorial');
   }
 


### PR DESCRIPTION
Add check in hook_install to load the editorial workflow directly from config/install if not present. This is to accommodate for installing via drush config-import where sometimes the hook_install is run before the workflow configuration is loaded. See https://github.com/localgovdrupal/localgov_workflows/issues/2 and https://www.drupal.org/project/drupal/issues/2906107