### PR TITLE
Replace call to drupal_get_path with ExtensionPathResolver::getPath

### DIFF
--- a/localgov_workflows.install
+++ b/localgov_workflows.install
@@ -29,7 +29,8 @@ function localgov_workflows_install($is_syncing) {
     }
     if (!$is_syncing || !$editorial_config) {
       // If workflow doesn't already exist load it from this module.
-      $config_source = new FileStorage(drupal_get_path('module', 'localgov_workflows') . '/config/install');
+      $config_file_path = \Drupal::service('extension.path.resolver')->getPath('module', 'localgov_workflows') . '/config/install';
+      $config_source = new FileStorage($config_file_path);
       $editorial_config = $config_source->read($config_key);
     }
     \Drupal::entityTypeManager()->getStorage('workflow')
@@ -100,7 +101,8 @@ function localgov_workflows_update_9001() {
   // not present.
   if (!Role::load(RolesHelper::CONTRIBUTOR_ROLE)) {
     $config_key = 'user.role.' . RolesHelper::CONTRIBUTOR_ROLE;
-    $source = new FileStorage(drupal_get_path('module', 'localgov_roles') . '/config/install');
+    $config_file_path = \Drupal::service('extension.path.resolver')->getPath('module', 'localgov_roles') . '/config/install';
+    $source = new FileStorage($config_file_path);
     $contributor_config = $source->read($config_key);
     \Drupal::entityTypeManager()->getStorage('user_role')
       ->create($contributor_config)

--- a/tests/src/Functional/RequireLogTest.php
+++ b/tests/src/Functional/RequireLogTest.php
@@ -32,8 +32,18 @@ class RequireLogTest extends BrowserTestBase {
   protected function setUp(): void {
     parent::setUp();
 
+    // Create an article content type that we will use for testing.
+    $type = $this->container->get('entity_type.manager')->getStorage('node_type')
+      ->create([
+        'type' => 'require_log_test',
+        'name' => 'Require log test',
+      ]);
+    $type->save();
+    $this->container->get('router.builder')->rebuild();
+
     $this->adminUser = $this->drupalCreateUser([
       'administer content types',
+      'create require_log_test content',
     ]);
 
     $this->drupalLogin($this->adminUser);
@@ -45,12 +55,10 @@ class RequireLogTest extends BrowserTestBase {
   public function testRequireLogContentType() {
     // Default is for content type to have revisions.
     // Require log message too.
-    $this->drupalGet('/admin/structure/types/add');
+    $this->drupalGet('/admin/structure/types/manage/require_log_test');
     $this->assertSession()->responseContains('Require revision log message');
     // Enabling field_ui will change that button.
     $this->submitForm([
-      'name' => 'require log test',
-      'type' => 'require_log_test',
       'options[revision_required]' => TRUE,
     ], 'Save content type');
 


### PR DESCRIPTION
Fix #27

Use \Drupal::service('extension.path.resolver')->getPath('module', 'localgov_workflows')
where required instead of deprectated drupal_get_path
