### PR TITLE
Use entity being reviewed as the label for the review entity

### DIFF
--- a/modules/localgov_review_date/src/Entity/ReviewDate.php
+++ b/modules/localgov_review_date/src/Entity/ReviewDate.php
@@ -88,9 +88,8 @@ class ReviewDate extends ContentEntityBase implements ReviewDateInterface {
   public function label() {
 
     // If this review references an entity, use that as the label.
-    $entity = $this->getEntity();
-    if ($entity instanceof EntityInterface) {
-      return $entity->label();
+    if ($this->hasEntity()) {
+      return $this->getEntity()->label();
     }
     return parent::label();
   }
@@ -138,6 +137,13 @@ class ReviewDate extends ContentEntityBase implements ReviewDateInterface {
   protected function setCreatedTime($created) {
     $this->set('created', $created);
     return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function hasEntity(): bool {
+    return ($this->get('entity')->entity instanceof EntityInterface);
   }
 
   /**

--- a/modules/localgov_review_date/src/Entity/ReviewDate.php
+++ b/modules/localgov_review_date/src/Entity/ReviewDate.php
@@ -85,6 +85,19 @@ class ReviewDate extends ContentEntityBase implements ReviewDateInterface {
   /**
    * {@inheritdoc}
    */
+  public function label() {
+
+    // If this review references an entity, use that as the label.
+    $entity = $this->getEntity();
+    if ($entity instanceof EntityInterface) {
+      return $entity->label();
+    }
+    return parent::label();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function isActive(): bool {
     return $this->get('active')->value;
   }

--- a/modules/localgov_review_date/src/Entity/ReviewDate.php
+++ b/modules/localgov_review_date/src/Entity/ReviewDate.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityStorageInterface;
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
 use Drupal\scheduled_transitions\Entity\ScheduledTransitionInterface;
 
 /**
@@ -32,6 +33,8 @@ use Drupal\scheduled_transitions\Entity\ScheduledTransitionInterface;
  * )
  */
 class ReviewDate extends ContentEntityBase implements ReviewDateInterface {
+
+  use StringTranslationTrait;
 
   /**
    * Workflow state that transition content to on the next review date.
@@ -89,7 +92,9 @@ class ReviewDate extends ContentEntityBase implements ReviewDateInterface {
 
     // If this review references an entity, use that as the label.
     if ($this->hasEntity()) {
-      return $this->getEntity()->label();
+      return $this->t('Review of @label', [
+        '@label' => $this->getEntity()->label(),
+      ]);
     }
     return parent::label();
   }

--- a/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
+++ b/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
@@ -126,6 +126,7 @@ class ReviewDateEntityTest extends KernelTestBase {
     $review_date = ReviewDate::newReviewDate($this->node, 'en', $scheduled_transition);
     $this->assertTrue($review_date->isActive());
     $this->assertEquals($this->node->id(), $review_date->getEntity()->id());
+    $this->assertEquals($this->node->label(), $review_date->label());
     $this->assertEquals('en', $review_date->getLanguage());
     $this->assertEquals($reviewed, $review_date->getReviewTime());
     $this->assertEquals($scheduled_transition->id(), $review_date->getScheduledTransition()->id());
@@ -144,6 +145,27 @@ class ReviewDateEntityTest extends KernelTestBase {
     $review_date->setScheduledTransition($scheduled_transition2);
     $this->assertEquals($reviewed2, $review_date->getReviewTime());
     $this->assertEquals($scheduled_transition2->id(), $review_date->getScheduledTransition()->id());
+
+    // Check a blank orphan review date.
+    $delete_node = $this->createNode([
+      'type' => 'page',
+      'title' => $this->randomMachineName(12),
+    ]);
+    $delete_reviewed = (new \DateTime('1 Jan 2020 12am'))->getTimestamp();
+    $delete_scheduled_transition = ScheduledTransition::create([
+      'entity' => $delete_node,
+      'entity_revision_id' => 1,
+      'author' => 1,
+      'workflow' => 'localgov_editorial',
+      'moderation_state' => 'published',
+      'transition_on' => $delete_reviewed,
+    ]);
+    $delete_review_date = ReviewDate::newReviewDate($delete_node, 'en', $delete_scheduled_transition);
+    $delete_node->delete();
+
+    // If there is no entity, label will be NULL.
+    // Assert here to verify no PHP error.
+    $this->assertNull($delete_review_date->label());
   }
 
   /**

--- a/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
+++ b/modules/localgov_review_date/tests/src/Kernel/ReviewDateEntityTest.php
@@ -126,7 +126,7 @@ class ReviewDateEntityTest extends KernelTestBase {
     $review_date = ReviewDate::newReviewDate($this->node, 'en', $scheduled_transition);
     $this->assertTrue($review_date->isActive());
     $this->assertEquals($this->node->id(), $review_date->getEntity()->id());
-    $this->assertEquals($this->node->label(), $review_date->label());
+    $this->assertEquals('Review of ' . $this->node->label(), $review_date->label());
     $this->assertEquals('en', $review_date->getLanguage());
     $this->assertEquals($reviewed, $review_date->getReviewTime());
     $this->assertEquals($scheduled_transition->id(), $review_date->getScheduledTransition()->id());


### PR DESCRIPTION
Fix https://github.com/localgovdrupal/localgov_workflows/issues/60

If the review has a parent entity (it should!) then use that as the label. This is to allow a more sensible display in Drupal UI in places like views bulk operations.

Also includes a test for the case when the review is orphaned (node is deleted)
