### PR TITLE
Remove review scheduled transitions when a page is archived

### DIFF
--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -161,35 +161,3 @@ function localgov_workflows_module_implements_alter(&$implementations, $hook) {
     $implementations = ['localgov_workflows' => $group] + $implementations;
   }
 }
-
-/**
- * Implements hook_node_update().
- */
-function localgov_workflows_node_update(NodeInterface $node) {
-
-  // Compare moderation state between original and saved node.
-  $original = $node->original;
-  $previous_state = $original->get('moderation_state')->getValue()[0]['value'];
-  $new_state = $node->get('moderation_state')->getValue()[0]['value'];
-
-  // If node is being moved into the archvied state,
-  // Find any scheduled transitions to review and delete them.
-  if ($previous_state != $new_state && $new_state == 'archived') {
-    $st_storage = \Drupal::entityTypeManager()->getStorage('scheduled_transition');
-    $st_ids = $st_storage->getQuery()
-      ->condition('workflow', 'localgov_editorial')
-      ->condition('entity__target_type', 'node')
-      ->condition('entity__target_id', $node->id())
-      ->accessCheck(FALSE)
-      ->execute();
-    $scheduled_transitions = $st_storage->loadMultiple($st_ids);
-    foreach ($scheduled_transitions as $scheduled_transition) {
-      // Using condition('moderation_state', 'review') above does not bring
-      // in any results, so do an if check here if the transition is in review
-      // and delete it.
-      if ($scheduled_transition->get('moderation_state')->value == 'review') {
-        $scheduled_transition->delete();
-      }
-    }
-  }
-}

--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -161,3 +161,35 @@ function localgov_workflows_module_implements_alter(&$implementations, $hook) {
     $implementations = ['localgov_workflows' => $group] + $implementations;
   }
 }
+
+/**
+ * Implements hook_node_update().
+ */
+function localgov_workflows_node_update(NodeInterface $node) {
+
+  // Compare moderation state between original and saved node.
+  $original = $node->original;
+  $previous_state = $original->get('moderation_state')->getValue()[0]['value'];
+  $new_state = $node->get('moderation_state')->getValue()[0]['value'];
+
+  // If node is being moved into the archvied state,
+  // Find any scheduled transitions to review and delete them.
+  if ($previous_state != $new_state && $new_state == 'archived') {
+    $st_storage = \Drupal::entityTypeManager()->getStorage('scheduled_transition');
+    $st_ids = $st_storage->getQuery()
+      ->condition('workflow', 'localgov_editorial')
+      ->condition('entity__target_type', 'node')
+      ->condition('entity__target_id', $node->id())
+      ->accessCheck(FALSE)
+      ->execute();
+    $scheduled_transitions = $st_storage->loadMultiple($st_ids);
+    foreach ($scheduled_transitions as $scheduled_transition) {
+      // Using condition('moderation_state', 'review') above does not bring
+      // in any results, so do an if check here if the transition is in review
+      // and delete it.
+      if ($scheduled_transition->get('moderation_state')->value == 'review') {
+        $scheduled_transition->delete();
+      }
+    }
+  }
+}

--- a/modules/localgov_review_date/localgov_review_date.module
+++ b/modules/localgov_review_date/localgov_review_date.module
@@ -83,5 +83,17 @@ function localgov_review_date_node_update(NodeInterface $node) {
         $scheduled_transition->delete();
       }
     }
+
+    // Also delete active review entities of this node.
+    $review_storage = \Drupal::entityTypeManager()->getStorage('review_date');
+    $review_ids = $review_storage->getQuery()
+      ->condition('entity', $node->id())
+      ->condition('active', 1)
+      ->accessCheck(FALSE)
+      ->execute();
+    $review_entities = $review_storage->loadMultiple($review_ids);
+    foreach ($review_entities as $review) {
+      $review->delete();
+    }
   }
 }

--- a/modules/localgov_review_date/localgov_review_date.module
+++ b/modules/localgov_review_date/localgov_review_date.module
@@ -8,6 +8,7 @@
 use Drupal\Core\Entity\EntityTypeInterface;
 use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\node\NodeInterface;
 
 /**
  * Implements hook_entity_bundle_field_info().
@@ -51,4 +52,36 @@ function localgov_review_date_form_scheduled_transitions_settings_submit(array $
   // transitions enabled. It's necessary to rebuild caches after making changes
   // to scheduled transitions to ensure the field is added.
   drupal_flush_all_caches();
+}
+
+/**
+ * Implements hook_node_update().
+ */
+function localgov_review_date_node_update(NodeInterface $node) {
+
+  // Compare moderation state between original and saved node.
+  $original = $node->original;
+  $previous_state = $original->get('moderation_state')->getValue()[0]['value'];
+  $new_state = $node->get('moderation_state')->getValue()[0]['value'];
+
+  // If node is being moved into the archvied state,
+  // Find any scheduled transitions to review and delete them.
+  if ($previous_state != $new_state && $new_state == 'archived') {
+    $st_storage = \Drupal::entityTypeManager()->getStorage('scheduled_transition');
+    $st_ids = $st_storage->getQuery()
+      ->condition('workflow', 'localgov_editorial')
+      ->condition('entity__target_type', 'node')
+      ->condition('entity__target_id', $node->id())
+      ->accessCheck(FALSE)
+      ->execute();
+    $scheduled_transitions = $st_storage->loadMultiple($st_ids);
+    foreach ($scheduled_transitions as $scheduled_transition) {
+      // Using condition('moderation_state', 'review') above does not bring
+      // in any results, so do an if check here if the transition is in review
+      // and delete it.
+      if ($scheduled_transition->get('moderation_state')->value == 'review') {
+        $scheduled_transition->delete();
+      }
+    }
+  }
 }

--- a/modules/localgov_review_date/tests/src/Functional/ArchiveNodeTest.php
+++ b/modules/localgov_review_date/tests/src/Functional/ArchiveNodeTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Drupal\Tests\localgov_review_date\Functional;
+
+use Drupal\Core\Cache\Cache;
+use Drupal\scheduled_transitions\Form\ScheduledTransitionsSettingsForm;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\workflows\Entity\Workflow;
+
+/**
+ * Tests that archived nodes no longer appear in review.
+ */
+class ArchiveNodeTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_review_date',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'testing';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create a page content type.
+    $this->drupalCreateContentType(['type' => 'page', 'name' => 'Basic page']);
+
+    // Add page to localgov_editorial workflow.
+    $editorial = Workflow::load('localgov_editorial');
+    $type = $editorial->getTypePlugin();
+    $type->addEntityTypeAndBundle('node', 'page');
+    $editorial->save();
+
+    // Configure scheduled transitions.
+    $scheduled_transitions_config = \Drupal::service('config.factory')->getEditable('scheduled_transitions.settings');
+    $bundles = [
+      [
+        'entity_type' => 'node',
+        'bundle' => 'page',
+      ],
+    ];
+    $scheduled_transitions_config->set('bundles', $bundles);
+    $scheduled_transitions_config->save();
+    Cache::invalidateTags([
+      ScheduledTransitionsSettingsForm::SETTINGS_TAG,
+      'config:scheduled_transitions.settings',
+    ]);
+
+    // Create test user and log in.
+    $web_user = $this->drupalCreateUser([
+      'access content',
+      'create page content',
+      'edit own page content',
+      'edit any page content',
+      'administer localgov_review_date',
+      'use localgov_editorial transition approve',
+      'use localgov_editorial transition archive',
+      'use localgov_editorial transition archived_draft',
+      'use localgov_editorial transition archived_published',
+      'use localgov_editorial transition create_new_draft',
+      'use localgov_editorial transition publish',
+      'use localgov_editorial transition reject',
+      'use localgov_editorial transition submit_for_review',
+      'view page revisions',
+      'view any unpublished content',
+      'view all scheduled transitions',
+      'add scheduled transitions node page',
+      'reschedule scheduled transitions node page',
+      'view scheduled transitions node page',
+    ]);
+    $this->drupalLogin($web_user);
+    drupal_flush_all_caches();
+  }
+
+  /**
+   * Verify that any archived nodes no longer appear in review views.
+   */
+  public function testArchviedNodeRemovesReview(): void {
+
+    // Create a published node and check the scheduled transition state.
+    $this->drupalGet('node/add/page');
+    $title = $this->randomMachineName(8);
+    $edit = [
+      'title[0][value]' => $title,
+      'moderation_state[0][state]' => 'published',
+      'localgov_review_date[0][reviewed]' => TRUE,
+    ];
+    $this->submitForm($edit, 'Save');
+    $node = $this->drupalGetNodeByTitle($title);
+
+    // This should have a review scheduled transition.
+    $this->drupalGet('node/' . $node->id() . '/scheduled-transitions');
+    $this->assertSession()->pageTextContains('Review');
+
+    // Archive the page.
+    $this->drupalGet('node/' . $node->id() . '/edit');
+    $edit = [
+      'moderation_state[0][state]' => 'archived',
+    ];
+    $this->submitForm($edit, 'Save');
+
+    // Should no longer have a scheduled transition.
+    $this->drupalGet('node/' . $node->id() . '/scheduled-transitions');
+    $this->assertSession()->pageTextNotContains('Review');
+
+    // Create node in the past that should have a review.
+    $this->drupalGet('node/add/page');
+    $title = $this->randomMachineName(8);
+    $edit = [
+      'title[0][value]' => $title,
+      'moderation_state[0][state]' => 'published',
+      'localgov_review_date[0][reviewed]' => TRUE,
+      'localgov_review_date[0][review][review_in]' => '12',
+      'localgov_review_date[0][review][review_date]' => date('Y-m-d', strtotime('-1 day')),
+    ];
+    $this->submitForm($edit, 'Save');
+    $node = $this->drupalGetNodeByTitle($title);
+
+    // Check page is listed in review.
+    $this->drupalGet('admin/content/localgov_review');
+    $this->assertSession()->pageTextContains($title);
+
+    // Archive page.
+    $this->drupalGet('node/' . $node->id() . '/edit');
+    $edit = [
+      'moderation_state[0][state]' => 'archived',
+    ];
+    $this->submitForm($edit, 'Save');
+
+    // Check page is no longer listed as in review.
+    $this->drupalGet('admin/content/localgov_review');
+    $this->assertSession()->pageTextNotContains($title);
+  }
+
+}


### PR DESCRIPTION
Ref #59

Implements the part of delete scheduled transitions by removing the review
scheduled transition from a page that has been archived.
