### PR TITLE
Rename workflow task tabs and fix content moderation view

### DIFF
--- a/config/install/views.view.localgov_approvals_dashboard.yml
+++ b/config/install/views.view.localgov_approvals_dashboard.yml
@@ -797,7 +797,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'No content waiting for approval. Only content in review is listed here.'
+          content: 'No content waiting for approval.'
           plugin_id: text_custom
       relationships:
         nid:

--- a/config/install/views.view.localgov_approvals_dashboard.yml
+++ b/config/install/views.view.localgov_approvals_dashboard.yml
@@ -784,7 +784,7 @@ display:
           entity_type: node
           plugin_id: moderation_state_filter
       sorts: {  }
-      title: 'Approvals dashboard'
+      title: 'Approve content'
       header: {  }
       footer: {  }
       empty:
@@ -842,7 +842,7 @@ display:
   approvals_dashboard:
     display_plugin: page
     id: approvals_dashboard
-    display_title: 'Approvals dashboard'
+    display_title: 'Approve content'
     position: 1
     display_options:
       display_extenders: {  }
@@ -850,7 +850,7 @@ display:
       display_description: 'LocalGov content waiting for approval'
       menu:
         type: normal
-        title: 'Approvals dashboard'
+        title: 'Approve content'
         description: ''
         expanded: false
         parent: system.admin_content

--- a/localgov_workflows.links.task.yml
+++ b/localgov_workflows.links.task.yml
@@ -1,5 +1,5 @@
 localgov_workflows.approvals_dashboard:
-  title: 'Approvals dashboard'
+  title: 'Approve'
   route_name: view.localgov_approvals_dashboard.approvals_dashboard
   parent_id: system.admin_content
   weight: 1

--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -14,6 +14,40 @@ use Drupal\node\NodeTypeInterface;
 use Drupal\workflows\Entity\Workflow;
 
 /**
+ * Implements hook_modules_installed().
+ */
+function localgov_workflows_modules_installed($modules, $is_syncing) {
+
+  // Fix the core moderated content view.
+  if (in_array('localgov_workflows', $modules) && !$is_syncing) {
+
+    // Don't change things if the core editorial workflow is enabled.
+    if (!is_null(\Drupal::entityTypeManager()->getStorage('workflow')->load('editorial'))) {
+      return;
+    }
+
+    $moderated_content_view = \Drupal::entityTypeManager()
+      ->getStorage('view')
+      ->load('moderated_content');
+    if ($moderated_content_view) {
+      $display = $moderated_content_view->get('display');
+      $filters = $display['default']['display_options']['filters'];
+      $filters['moderation_state']['value'] = [
+        'localgov_editorial-draft' => 'localgov_editorial-draft',
+        'localgov_editorial-review' => 'localgov_editorial-review',
+        'localgov_editorial-archived' => 'localgov_editorial-archived',
+      ];
+      $filters['moderation_state_1']['value'] = [
+        'localgov_editorial-published' => 'localgov_editorial-published',
+      ];
+      $display['default']['display_options']['filters'] = $filters;
+      $moderated_content_view->set('display', $display);
+      $moderated_content_view->save();
+    }
+  }
+}
+
+/**
  * Implements hook_localgov_roles_default().
  */
 function localgov_workflows_localgov_roles_default(): array {

--- a/modules/localgov_review_date/config/install/views.view.localgov_needs_review.yml
+++ b/modules/localgov_review_date/config/install/views.view.localgov_needs_review.yml
@@ -818,7 +818,7 @@ display:
         operator: AND
         groups:
           1: AND
-      title: 'Needs review'
+      title: 'Review content'
     cache_metadata:
       max-age: -1
       contexts:
@@ -831,7 +831,7 @@ display:
   needs_review:
     display_plugin: page
     id: needs_review
-    display_title: 'Needs review'
+    display_title: 'Review content'
     position: 1
     display_options:
       display_extenders: {  }
@@ -839,13 +839,13 @@ display:
       path: admin/content/localgov_review
       menu:
         type: normal
-        title: 'Needs review'
+        title: 'Review content'
         description: ''
         expanded: false
         parent: ''
         weight: 0
         context: '0'
-        menu_name: main
+        menu_name: admin
     cache_metadata:
       max-age: -1
       contexts:

--- a/modules/localgov_review_date/config/install/views.view.localgov_needs_review.yml
+++ b/modules/localgov_review_date/config/install/views.view.localgov_needs_review.yml
@@ -798,7 +798,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'No content waiting for review.'
+          content: 'No content has passed its review date.'
           plugin_id: text_custom
       relationships:
         entity:

--- a/modules/localgov_review_date/localgov_review_date.links.task.yml
+++ b/modules/localgov_review_date/localgov_review_date.links.task.yml
@@ -1,5 +1,5 @@
 localgov_review_date.needs_review:
-  title: 'Needs review'
+  title: 'Review'
   route_name: view.localgov_needs_review.needs_review
   parent_id: system.admin_content
   weight: 2

--- a/tests/src/Functional/ApprovalsDashboardTest.php
+++ b/tests/src/Functional/ApprovalsDashboardTest.php
@@ -39,7 +39,7 @@ class ApprovalsDashboardTest extends BrowserTestBase {
 
     // Test approvals dashboard tab is visible and content moderation in hidden.
     $this->drupalGet('admin/content');
-    $this->assertSession()->responseContains('Approvals dashboard');
+    $this->assertSession()->responseContains('Approve');
     $this->assertSession()->responseNotContains('Content moderation');
 
     // Test content moderation tab is visible after enabling another workflow.
@@ -49,7 +49,7 @@ class ApprovalsDashboardTest extends BrowserTestBase {
     ], 'workflow');
     $workflow->save();
     $this->drupalGet('admin/content');
-    $this->assertSession()->responseContains('Approvals dashboard');
+    $this->assertSession()->responseContains('Approve');
     $this->assertSession()->responseContains('Moderated content');
   }
 


### PR DESCRIPTION
Renames the approvals dashboard and content review tabs and fixes the core content moderation view.

Fixes #53