### PR TITLE
Fix running tests with Paratest in Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,3 @@
-##
-# Managed by https://github.com/localgovdrupal/github_workflow_manager
----
 name: Test localgovdrupal/localgov_workflows drupal-module
 
 on:
@@ -211,4 +208,4 @@ jobs:
           mkdir -p ./html/web/sites/simpletest && chmod 777 ./html/web/sites/simpletest
           sed -i "s#http://localgov.lndo.site#http://drupal#" ./html/phpunit.xml.dist
           docker exec -t drupal bash -c 'chown docker:docker -R /var/www/html'
-          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 ${{ env.LOCALGOV_DRUPAL_PROJECT_PATH }}"
+          docker exec -u docker -t drupal bash -c "cd /var/www/html && ./bin/paratest --processes=4 /var/www/html/${{ env.LOCALGOV_DRUPAL_PROJECT_PATH }}"


### PR DESCRIPTION
Issue for failing code deprecation: https://github.com/localgovdrupal/localgov_workflows/issues/76

There's also a test failure that needs looking at

```
1) Drupal\Tests\localgov_workflows\Functional\RequireLogTest::testRequireLogContentType
Behat\Mink\Exception\ElementNotFoundException: Button with id|name|label|value "Save content type" not found.

/var/www/html/web/core/tests/Drupal/Tests/WebAssert.php:144
/var/www/html/web/core/tests/Drupal/Tests/UiHelperTrait.php:78
/var/www/html/web/modules/contrib/localgov_workflows/tests/src/Functional/RequireLogTest.php:70
/var/www/html/vendor/phpunit/phpunit/src/Framework/TestResult.php:728
```