### PR TITLE
Updating local task weights (localgov Issue 718)

### DIFF
--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -152,6 +152,10 @@ function localgov_workflows_menu_local_tasks_alter(&$data, $route_name, Refinabl
     $arguments['@title'] = 'Scheduling';
     $data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'] = t($title->getUntranslatedString(), $arguments); // phpcs:ignore.
   }
+    // Alter "Scheduled transitions" weight.
+    if (isset($data['tabs'][0]['entity.scheduled_transition.collection'])) {
+        $data['tabs'][0]['entity.scheduled_transition.collection']['#weight'] = 70;
+    }
 
   // Rename 'Moderated content' tab to 'Unpublished'.
   if (isset($data['tabs'][1]['content_moderation.workflows:content_moderation.moderated_content'])) {

--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -145,7 +145,7 @@ function localgov_workflows_menu_local_tasks_alter(&$data, $route_name, Refinabl
   // Rename 'Scheduled transitions' tab to 'Scheduling' and increase its weight.
   if (isset($data['tabs'][0]['entity.scheduled_transition.collection'])) {
     $data['tabs'][0]['entity.scheduled_transition.collection']['#link']['title'] = t('Scheduling');
-      $data['tabs'][0]['entity.scheduled_transition.collection']['#weight'] = 70;
+    $data['tabs'][0]['entity.scheduled_transition.collection']['#weight'] = 70;
   }
   if (isset($data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'])) {
     $title = $data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'];

--- a/localgov_workflows.module
+++ b/localgov_workflows.module
@@ -142,9 +142,10 @@ function localgov_workflows_menu_local_tasks_alter(&$data, $route_name, Refinabl
     }
   }
 
-  // Rename 'Scheduled transitions' tab to 'Scheduling'.
+  // Rename 'Scheduled transitions' tab to 'Scheduling' and increase its weight.
   if (isset($data['tabs'][0]['entity.scheduled_transition.collection'])) {
     $data['tabs'][0]['entity.scheduled_transition.collection']['#link']['title'] = t('Scheduling');
+      $data['tabs'][0]['entity.scheduled_transition.collection']['#weight'] = 70;
   }
   if (isset($data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'])) {
     $title = $data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'];
@@ -152,10 +153,6 @@ function localgov_workflows_menu_local_tasks_alter(&$data, $route_name, Refinabl
     $arguments['@title'] = 'Scheduling';
     $data['tabs'][0]['scheduled_transitions.tasks:node.scheduled_transitions']['#link']['title'] = t($title->getUntranslatedString(), $arguments); // phpcs:ignore.
   }
-    // Alter "Scheduled transitions" weight.
-    if (isset($data['tabs'][0]['entity.scheduled_transition.collection'])) {
-        $data['tabs'][0]['entity.scheduled_transition.collection']['#weight'] = 70;
-    }
 
   // Rename 'Moderated content' tab to 'Unpublished'.
   if (isset($data['tabs'][1]['content_moderation.workflows:content_moderation.moderated_content'])) {

--- a/modules/localgov_workflows_notifications/localgov_workflows_notifications.links.task.yml
+++ b/modules/localgov_workflows_notifications/localgov_workflows_notifications.links.task.yml
@@ -15,4 +15,4 @@ entity.localgov_service_contact.collection:
   title: 'Service contacts'
   route_name: entity.localgov_service_contact.collection
   base_route: system.admin_content
-  weight: 10
+  weight: 80


### PR DESCRIPTION
Updating the weight of the following local tasks:

- Scheduling (former "Scheduled transitions")
- Service contacts

This PR is part of https://github.com/localgovdrupal/localgov/issues/718.