### PR TITLE
fix: drop drupal 10.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
+        "drupal/core": "^10.2",
         "drupal/diff": "^1.0",
         "drupal/responsive_preview": "^2.0",
         "drupal/scheduled_transitions": "^2.1",

--- a/localgov_workflows.info.yml
+++ b/localgov_workflows.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Workflows
 description: Provides the default editorial workflow for content types.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10.2
 
 dependencies:
   - drupal:content_moderation

--- a/tests/src/Kernel/WorkflowsInstallTest.php
+++ b/tests/src/Kernel/WorkflowsInstallTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\localgov_workflows\Kernel;
 
 use Drupal\KernelTests\KernelTestBase;
-use Drupal\Tests\field\Traits\EntityReferenceTestTrait;
+use Drupal\Tests\field\Traits\EntityReferenceFieldCreationTrait;
 use Drupal\Tests\node\Traits\ContentTypeCreationTrait;
 use Drupal\Tests\node\Traits\NodeCreationTrait;
 use Drupal\Tests\pathauto\Functional\PathautoTestHelperTrait;
@@ -17,10 +17,7 @@ use Drupal\workflows\Entity\Workflow;
 class WorkflowsInstallTest extends KernelTestBase {
 
   use ContentTypeCreationTrait;
-  // FIXME: Replace with EntityReferenceFieldCreationTrait when Drupal 10.1 is
-  // end of life.
-  // @phpstan-ignore-next-line.
-  use EntityReferenceTestTrait;
+  use EntityReferenceFieldCreationTrait;
   use NodeCreationTrait;
   use PathautoTestHelperTrait;
 


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Drop Drupal 10.1 support, 10.1 was EoL June 2024

Change record: https://www.drupal.org/node/3401941