### PR TITLE
feat: drupal 11 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "GPL-2.0-or-later",
     "minimum-stability": "dev",
     "require": {
-        "drupal/core": "^10.2",
+        "drupal/core": "^10.2 || ^11.0",
         "drupal/diff": "^1.0",
         "drupal/responsive_preview": "^2.0",
         "drupal/scheduled_transitions": "^2.1",

--- a/localgov_workflows.info.yml
+++ b/localgov_workflows.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Workflows
 description: Provides the default editorial workflow for content types.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^10.2
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:content_moderation

--- a/modules/localgov_review_date/localgov_review_date.info.yml
+++ b/modules/localgov_review_date/localgov_review_date.info.yml
@@ -2,7 +2,7 @@ name: LocalGov Review Date
 description: Provides a review dates entity and widget, along with views for managing content reviews.
 package: LocalGov Drupal
 type: module
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 
 dependencies:
   - drupal:content_moderation

--- a/modules/localgov_workflows_notifications/localgov_workflows_notifications.info.yml
+++ b/modules/localgov_workflows_notifications/localgov_workflows_notifications.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Workflows Notifications'
 type: module
 description: 'Send notifications to service contacts when content needs reviewing.'
 package: LocalGov Drupal
-core_version_requirement: ^9 || ^10
+core_version_requirement: ^10 || ^11
 dependencies:
   - localgov_workflows:localgov_workflows
   - symfony_mailer:symfony_mailer

--- a/modules/localgov_workflows_notifications/localgov_workflows_notifications.info.yml
+++ b/modules/localgov_workflows_notifications/localgov_workflows_notifications.info.yml
@@ -2,7 +2,7 @@ name: 'LocalGov Workflows Notifications'
 type: module
 description: 'Send notifications to service contacts when content needs reviewing.'
 package: LocalGov Drupal
-core_version_requirement: ^10 || ^11
+core_version_requirement: ^10.2 || ^11
 dependencies:
   - localgov_workflows:localgov_workflows
   - symfony_mailer:symfony_mailer

--- a/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
+++ b/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
@@ -3,6 +3,7 @@
 namespace Drupal\localgov_workflows_notifications\Form;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\TypedConfigManagerInterface;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\localgov_workflows_notifications\NotificationTimer;
@@ -27,12 +28,12 @@ final class LocalgovWorkflowsNotificationsSettingsForm extends ConfigFormBase {
    *   The factory for configuration objects.
    * @param \Drupal\localgov_workflows_notifications\NotificationTimer $notification_timer
    *   The notification timer service.
-   * @param \Drupal\Core\Config\TypedConfigManagerInterface|null $typedConfigManager
+   * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
    *   The typed config manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, NotificationTimer $notification_timer, protected $typedConfigManager = NULL) {
+  public function __construct(ConfigFactoryInterface $config_factory, NotificationTimer $notification_timer, protected TypedConfigManagerInterface $typed_config_manager) {
     $this->timer = $notification_timer;
-    parent::__construct($config_factory, $typedConfigManager);
+    parent::__construct($config_factory, $typed_config_manager);
   }
 
   /**

--- a/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
+++ b/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
@@ -31,7 +31,7 @@ final class LocalgovWorkflowsNotificationsSettingsForm extends ConfigFormBase {
    * @param \Drupal\Core\Config\TypedConfigManagerInterface $typed_config_manager
    *   The typed config manager.
    */
-  public function __construct(ConfigFactoryInterface $config_factory, NotificationTimer $notification_timer, protected TypedConfigManagerInterface $typed_config_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, NotificationTimer $notification_timer, TypedConfigManagerInterface $typed_config_manager) {
     $this->timer = $notification_timer;
     parent::__construct($config_factory, $typed_config_manager);
   }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fixes #114, the bump to 10.2 minimum is for https://www.drupal.org/node/3404140

## How to test

```bash
composer require localgovdrupal/localgov_workflows:"dev-feature/1.x/drupal-11-support as 1.3.8"
```

Fails are eslint only.

## How can we measure success?

Module works with both D10 and D11