### PR TITLE
Add option to reset last notification time

### DIFF
--- a/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
+++ b/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
@@ -79,18 +79,18 @@ final class LocalgovWorkflowsNotificationsSettingsForm extends ConfigFormBase {
       '#default_value' => $this->config('localgov_workflows_notifications.settings')->get('email_frequency') ?? 1,
     ];
 
-    $form['debug_options'] = [
+    $form['test_options'] = [
       '#type' => 'details',
-      '#title' => $this->t('Debug options'),
+      '#title' => $this->t('Testing options'),
       '#open' => FALSE,
     ];
-    $form['debug_options']['reset_timer'] = [
+    $form['test_options']['reset_help'] = [
       '#type' => 'item',
       '#markup' => $this->t('<p>Last run time: @time</p><p>Resetting the last run time will force notifications to be sent for all content needing review. This is useful when testing email notifications.</p>', [
         '@time' => $this->timer->getLastRun() ? date('F j Y, g:ia', $this->timer->getLastRun()) : $this->t('Never'),
       ]),
     ];
-    $form['debug_options']['reset_last_run'] = [
+    $form['test_options']['reset_last_run'] = [
       '#type' => 'submit',
       '#value' => $this->t('Rest last run time'),
       '#submit' => ['::resetLastRun'],

--- a/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
+++ b/modules/localgov_workflows_notifications/src/Form/LocalgovWorkflowsNotificationsSettingsForm.php
@@ -79,6 +79,23 @@ final class LocalgovWorkflowsNotificationsSettingsForm extends ConfigFormBase {
       '#default_value' => $this->config('localgov_workflows_notifications.settings')->get('email_frequency') ?? 1,
     ];
 
+    $form['debug_options'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Debug options'),
+      '#open' => FALSE,
+    ];
+    $form['debug_options']['reset_timer'] = [
+      '#type' => 'item',
+      '#markup' => $this->t('<p>Last run time: @time</p><p>Resetting the last run time will force notifications to be sent for all content needing review. This is useful when testing email notifications.</p>', [
+        '@time' => $this->timer->getLastRun() ? date('F j Y, g:ia', $this->timer->getLastRun()) : $this->t('Never'),
+      ]),
+    ];
+    $form['debug_options']['reset_last_run'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Rest last run time'),
+      '#submit' => ['::resetLastRun'],
+    ];
+
     return parent::buildForm($form, $form_state);
   }
 
@@ -100,6 +117,13 @@ final class LocalgovWorkflowsNotificationsSettingsForm extends ConfigFormBase {
       ->save();
 
     parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Reset last run time submit handler.
+   */
+  public function resetLastRun(array &$form, FormStateInterface $form_state): void {
+    $this->timer->reset();
   }
 
 }

--- a/modules/localgov_workflows_notifications/src/NotificationTimer.php
+++ b/modules/localgov_workflows_notifications/src/NotificationTimer.php
@@ -52,6 +52,13 @@ class NotificationTimer implements NotificationTimerInterface {
   /**
    * {@inheritdoc}
    */
+  public function reset(): void {
+    $this->state->set(self::LAST_RUN, 0);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function update(): void {
     $request_time = $this->time->getRequestTime();
     $this->state->set(self::LAST_RUN, $request_time);

--- a/modules/localgov_workflows_notifications/src/NotificationTimerInterface.php
+++ b/modules/localgov_workflows_notifications/src/NotificationTimerInterface.php
@@ -23,6 +23,11 @@ interface NotificationTimerInterface {
   public function getLastRun(): ?int;
 
   /**
+   * Reset the notification timer.
+   */
+  public function reset(): void;
+
+  /**
    * Update the notification timer.
    */
   public function update(): void;


### PR DESCRIPTION
Fixes #122

## What does this change?

Adds a debug option to reset last notification time. This helps with debugging sending email notifications.

![image](https://github.com/user-attachments/assets/c12590d6-5d02-411c-afa3-4528ef9e8aea)

## How to test

Enable Review Date and Workflows Notifications modules. Create some content with associated service contacts. Set review date to some time in the past on the content. Run cron - email notifications should be sent. Click 'Reset last run time'. Run cron again - notification emails will be sent again.

