### PR TITLE
Fix regression bug with notification type enqueuing as separate notification

### DIFF
--- a/modules/localgov_workflows_notifications/src/WorkflowNotification.php
+++ b/modules/localgov_workflows_notifications/src/WorkflowNotification.php
@@ -42,11 +42,11 @@ class WorkflowNotification implements WorkflowNotificationInterface {
           continue;
         }
 
-        // Ensure the queue contains only one item for per service contact.
+        // Ensure the queue contains only one item for per service contact and type.
         $found = FALSE;
         $claimed_items = [];
         while ($queue_item = $queue->claimItem(1)) {
-          if ($queue_item->data->service_contact == $contact->id()) {
+          if ($queue_item->data->service_contact == $contact->id() && $queue_item->data->type == $type) {
 
             // Delete old item and create new one with additional entity.
             $queue->deleteItem($queue_item);

--- a/modules/localgov_workflows_notifications/src/WorkflowNotification.php
+++ b/modules/localgov_workflows_notifications/src/WorkflowNotification.php
@@ -46,7 +46,7 @@ class WorkflowNotification implements WorkflowNotificationInterface {
         $found = FALSE;
         $claimed_items = [];
         while ($queue_item = $queue->claimItem(1)) {
-          if ($queue_item->data->service_contact == $contact->id() && $queue_item->data->type == $type) {
+          if ($queue_item->data->service_contact == $contact->id() && $queue_item->data->type === $type) {
 
             // Delete old item and create new one with additional entity.
             $queue->deleteItem($queue_item);

--- a/modules/localgov_workflows_notifications/src/WorkflowNotification.php
+++ b/modules/localgov_workflows_notifications/src/WorkflowNotification.php
@@ -42,7 +42,7 @@ class WorkflowNotification implements WorkflowNotificationInterface {
           continue;
         }
 
-        // Ensure the queue contains only one item for per service contact and type.
+        // Aggregate notifications by service contact and type.
         $found = FALSE;
         $claimed_items = [];
         while ($queue_item = $queue->claimItem(1)) {

--- a/modules/localgov_workflows_notifications/tests/src/Kernel/WorkflowNotificationTest.php
+++ b/modules/localgov_workflows_notifications/tests/src/Kernel/WorkflowNotificationTest.php
@@ -166,7 +166,7 @@ class WorkflowNotificationTest extends KernelTestBase {
     $this->notifier->enqueue($node5, 'published');
     $this->assertEquals(2, $this->queue->numberOfItems());
 
-    // Enqueue a notification with different type.
+    // Ensure notifications are not duplicated.
     $node6 = $this->createNode([
       'type' => 'page',
       'title' => $this->randomMachineName(),
@@ -175,6 +175,17 @@ class WorkflowNotificationTest extends KernelTestBase {
       ],
     ]);
     $this->notifier->enqueue($node6, 'published');
+    $this->assertEquals(2, $this->queue->numberOfItems());
+
+    // Enqueue a notification with different type.
+    $node7 = $this->createNode([
+      'type' => 'page',
+      'title' => $this->randomMachineName(),
+      'localgov_service_contacts' => [
+        ['target_id' => $this->serviceContacts['enabled']->id()],
+      ],
+    ]);
+    $this->notifier->enqueue($node7, 'unpublished');
     $this->assertEquals(3, $this->queue->numberOfItems());
   }
 


### PR DESCRIPTION
Fixes #137

## What does this change?

Enqueues notifications depending on service contact and notification type, not just on service contact

With #134 a fix was committed that ensures email notifications were aggregated, but this exposed another error. A notification type is designed to use it's own email template and so needs to be enqueued separately. This happened previously as notifications weren't aggregated, now they are they are not separated by type. 

## How to test

There's only one notification type currently defined, so as long as the tests pass I think it's good to merge :smile: 